### PR TITLE
Role dependent event views

### DIFF
--- a/backend/src/main/java/de/neuefische/backend/controller/EventController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/EventController.java
@@ -2,6 +2,7 @@ package de.neuefische.backend.controller;
 
 import de.neuefische.backend.dto.EventDTO;
 import de.neuefische.backend.model.Event;
+import de.neuefische.backend.model.EventCategory;
 import de.neuefische.backend.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,21 @@ public class EventController {
         return eventService.findAllEvents();
     }
 
+    @GetMapping("/byCategories")
+    public List<Event> getEventsByCategories(@RequestParam(value = "categories") List<EventCategory> categories) {
+        return eventService.findEventsByCategory(categories);
+    }
+
+    @GetMapping("/creator/{creator}")
+    public List<Event> getEventsByCreator(@PathVariable String creator) {
+        return eventService.findEventsByCreator(creator);
+    }
+
+    @GetMapping("/status/{status}")
+    public List<Event> getEventsByStatus(@PathVariable String status) {
+        return eventService.findEventsByStatus(status);
+    }
+
     @GetMapping("{id}")
     public Event getEventById(@PathVariable String id) {
         return eventService.findEventById(id);
@@ -64,6 +80,11 @@ public class EventController {
     @DeleteMapping("{id}")
     public void deleteEvent(@PathVariable String id) {
         eventService.deleteEvent(id);
+    }
+
+    @GetMapping("/categories")
+    public EventCategory[] getEventCategories() {
+        return EventCategory.values();
     }
 
 }

--- a/backend/src/main/java/de/neuefische/backend/controller/UserController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/UserController.java
@@ -2,6 +2,7 @@ package de.neuefische.backend.controller;
 
 import de.neuefische.backend.dto.EventHubUserDTO;
 import de.neuefische.backend.dto.UserLoginAndRegistrationDTO;
+import de.neuefische.backend.dto.UserPreferredCategoriesDTO;
 import de.neuefische.backend.service.EventHubUserDetailService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,8 @@ public class UserController {
     UserLoginAndRegistrationDTO login() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         List<String> roles = authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
-        return new UserLoginAndRegistrationDTO().withUsername(authentication.getName()).withRoles(roles);
+        List<String> userPreferredCategories = service.getUserPreferredCategories(authentication.getName());
+        return new UserLoginAndRegistrationDTO().withUsername(authentication.getName()).withRoles(roles).withPreferredCategories(userPreferredCategories);
     }
 
     @PostMapping("/logout")
@@ -38,5 +40,10 @@ public class UserController {
     @ResponseStatus(HttpStatus.CREATED)
     public EventHubUserDTO postNewUser(@RequestBody UserLoginAndRegistrationDTO user) {
         return service.saveUser(user);
+    }
+
+    @PutMapping("/update-preferred-categories")
+    public UserPreferredCategoriesDTO updatePreferredCategories(@RequestBody UserPreferredCategoriesDTO userPreferredCategories) {
+       return service.updateUserPreferredCategories(userPreferredCategories);
     }
 }

--- a/backend/src/main/java/de/neuefische/backend/controller/UserController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
     }
 
     @PutMapping("/update-preferred-categories")
-    public UserPreferredCategoriesDTO updatePreferredCategories(@RequestBody UserPreferredCategoriesDTO userPreferredCategories) {
+    public EventHubUserDTO updatePreferredCategories(@RequestBody UserPreferredCategoriesDTO userPreferredCategories) {
        return service.updateUserPreferredCategories(userPreferredCategories);
     }
 }

--- a/backend/src/main/java/de/neuefische/backend/dto/EventHubUserDTO.java
+++ b/backend/src/main/java/de/neuefische/backend/dto/EventHubUserDTO.java
@@ -1,5 +1,6 @@
 package de.neuefische.backend.dto;
 
+import de.neuefische.backend.model.EventCategory;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,4 +14,5 @@ public class EventHubUserDTO {
     private String id;
     private String username;
     private List<String> roles;
+    private List<EventCategory> preferredCategories;
 }

--- a/backend/src/main/java/de/neuefische/backend/dto/UserLoginAndRegistrationDTO.java
+++ b/backend/src/main/java/de/neuefische/backend/dto/UserLoginAndRegistrationDTO.java
@@ -15,4 +15,5 @@ public class UserLoginAndRegistrationDTO {
     private String username;
     private String password;
     private List<String> roles;
+    private List<String> preferredCategories;
 }

--- a/backend/src/main/java/de/neuefische/backend/dto/UserPreferredCategoriesDTO.java
+++ b/backend/src/main/java/de/neuefische/backend/dto/UserPreferredCategoriesDTO.java
@@ -1,11 +1,15 @@
 package de.neuefische.backend.dto;
 
 import de.neuefische.backend.model.EventCategory;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserPreferredCategoriesDTO {
     private String username;
     private List<EventCategory> categories;

--- a/backend/src/main/java/de/neuefische/backend/dto/UserPreferredCategoriesDTO.java
+++ b/backend/src/main/java/de/neuefische/backend/dto/UserPreferredCategoriesDTO.java
@@ -1,0 +1,12 @@
+package de.neuefische.backend.dto;
+
+import de.neuefische.backend.model.EventCategory;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserPreferredCategoriesDTO {
+    private String username;
+    private List<EventCategory> categories;
+}

--- a/backend/src/main/java/de/neuefische/backend/model/EventHubUser.java
+++ b/backend/src/main/java/de/neuefische/backend/model/EventHubUser.java
@@ -17,4 +17,5 @@ public class EventHubUser {
     private String username;
     private String password;
     private List<SimpleGrantedAuthority> roles;
+    private List<EventCategory> preferredCategories;
 }

--- a/backend/src/main/java/de/neuefische/backend/model/EventStatus.java
+++ b/backend/src/main/java/de/neuefische/backend/model/EventStatus.java
@@ -1,5 +1,5 @@
 package de.neuefische.backend.model;
 
 public enum EventStatus {
-    NEW, APPROVED, DENIED
+    NEW, APPROVED, DECLINED
 }

--- a/backend/src/main/java/de/neuefische/backend/repository/EventRepository.java
+++ b/backend/src/main/java/de/neuefische/backend/repository/EventRepository.java
@@ -1,9 +1,15 @@
 package de.neuefische.backend.repository;
 
 import de.neuefische.backend.model.Event;
+import de.neuefische.backend.model.EventCategory;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface EventRepository extends MongoRepository<Event,String> {
+    List<Event> findByStatus(String status);
+    List<Event> findByCategoryIn(List<EventCategory> categories);
+    List<Event> findByCreator(String creator);
 }

--- a/backend/src/main/java/de/neuefische/backend/service/EventHubUserDetailService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/EventHubUserDetailService.java
@@ -50,7 +50,7 @@ public class EventHubUserDetailService implements UserDetailsService {
 
         EventHubUser temp = userRepository.save(newUser.withRoles(Collections.singletonList(new SimpleGrantedAuthority("user"))).withPassword(passwordEncoder.encode(user.getPassword())));
         List<String> roles = temp.getRoles().stream().map(SimpleGrantedAuthority::toString).toList();
-        return new EventHubUserDTO(temp.getId(), temp.getUsername(), roles);
+        return new EventHubUserDTO(temp.getId(), temp.getUsername(), roles, temp.getPreferredCategories());
     }
 
     public List<String> getUserPreferredCategories(String username) {
@@ -67,12 +67,12 @@ public class EventHubUserDetailService implements UserDetailsService {
                 .map(EventCategory::toString).toList();
     }
 
-    public UserPreferredCategoriesDTO updateUserPreferredCategories(UserPreferredCategoriesDTO userPreferredCategories) {
+    public EventHubUserDTO updateUserPreferredCategories(UserPreferredCategoriesDTO userPreferredCategories) {
         EventHubUser user = userRepository.findEventHubUserByUsername(userPreferredCategories.getUsername())
                 .orElseThrow(() -> new UsernameNotFoundException(String.format(USER_NOT_FOUND_MESSAGE, userPreferredCategories.getUsername())));
         user.setPreferredCategories(userPreferredCategories.getCategories());
         userRepository.save(user);
-        return userPreferredCategories;
+        return new EventHubUserDTO(user.getId(), user.getUsername(), user.getRoles().stream().map(SimpleGrantedAuthority::toString).toList(), user.getPreferredCategories());
     }
 
 }

--- a/backend/src/main/java/de/neuefische/backend/service/EventHubUserDetailService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/EventHubUserDetailService.java
@@ -48,9 +48,9 @@ public class EventHubUserDetailService implements UserDetailsService {
             throw new IllegalArgumentException("User with username " + user.getUsername() + " already exists");
         }
 
-        EventHubUser temp = userRepository.save(newUser.withRoles(Collections.singletonList(new SimpleGrantedAuthority("user"))).withPassword(passwordEncoder.encode(user.getPassword())));
-        List<String> roles = temp.getRoles().stream().map(SimpleGrantedAuthority::toString).toList();
-        return new EventHubUserDTO(temp.getId(), temp.getUsername(), roles, temp.getPreferredCategories());
+        EventHubUser savedUser = userRepository.save(newUser.withRoles(Collections.singletonList(new SimpleGrantedAuthority("user"))).withPassword(passwordEncoder.encode(user.getPassword())));
+        List<String> roles = savedUser.getRoles().stream().map(SimpleGrantedAuthority::toString).toList();
+        return new EventHubUserDTO(savedUser.getId(), savedUser.getUsername(), roles, savedUser.getPreferredCategories());
     }
 
     public List<String> getUserPreferredCategories(String username) {
@@ -61,18 +61,18 @@ public class EventHubUserDetailService implements UserDetailsService {
 
         if (preferredCategories == null) {
             return Collections.emptyList();
+        } else {
+            return preferredCategories.stream()
+                    .map(EventCategory::toString).toList();
         }
-
-        return user.getPreferredCategories().stream()
-                .map(EventCategory::toString).toList();
     }
 
     public EventHubUserDTO updateUserPreferredCategories(UserPreferredCategoriesDTO userPreferredCategories) {
-        EventHubUser user = userRepository.findEventHubUserByUsername(userPreferredCategories.getUsername())
+        EventHubUser userToUpdate = userRepository.findEventHubUserByUsername(userPreferredCategories.getUsername())
                 .orElseThrow(() -> new UsernameNotFoundException(String.format(USER_NOT_FOUND_MESSAGE, userPreferredCategories.getUsername())));
-        user.setPreferredCategories(userPreferredCategories.getCategories());
-        userRepository.save(user);
-        return new EventHubUserDTO(user.getId(), user.getUsername(), user.getRoles().stream().map(SimpleGrantedAuthority::toString).toList(), user.getPreferredCategories());
+        userToUpdate.setPreferredCategories(userPreferredCategories.getCategories());
+        userRepository.save(userToUpdate);
+        return new EventHubUserDTO(userToUpdate.getId(), userToUpdate.getUsername(), userToUpdate.getRoles().stream().map(SimpleGrantedAuthority::toString).toList(), userToUpdate.getPreferredCategories());
     }
 
 }

--- a/backend/src/main/java/de/neuefische/backend/service/EventService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/EventService.java
@@ -1,6 +1,7 @@
 package de.neuefische.backend.service;
 
 import de.neuefische.backend.model.Event;
+import de.neuefische.backend.model.EventCategory;
 import de.neuefische.backend.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,18 @@ public class EventService {
 
     public Event findEventById(String id) {
         return eventRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Event with id " + id + " does not exist"));
+    }
+
+    public List<Event> findEventsByCategory(List<EventCategory> categories) {
+        return eventRepository.findByCategoryIn(categories);
+    }
+
+    public List<Event> findEventsByCreator(String creator) {
+        return eventRepository.findByCreator(creator);
+    }
+
+    public List<Event> findEventsByStatus(String status) {
+        return eventRepository.findByStatus(status);
     }
 
     public Event updateEvent(String id, Event event) {

--- a/backend/src/test/java/de/neuefische/backend/controller/EventControllerTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/EventControllerTest.java
@@ -181,7 +181,7 @@ class EventControllerTest {
     @Test
     @DirtiesContext
     @WithMockUser
-    void deleteEvent() throws Exception {
+    void testDeleteEvent() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -211,5 +211,369 @@ class EventControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.get("/api/event/" + addedEvent.getId()))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser
+    void testGetEventsByCategories() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 1",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 1",
+                                        "category": "MUSIC",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 2",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 2",
+                                        "category": "ARTS",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 3",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 3",
+                                        "category": "MUSIC",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 4",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 4",
+                                        "category": "THEATRE",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/byCategories?categories=MUSIC,SPORTS,ARTS"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                             {
+                                        "title": "Title 1",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 1",
+                                        "category": "MUSIC",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                             },
+                             {
+                                        "title": "Title 2",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 2",
+                                        "category": "ARTS",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                                },
+                             {
+                                        "title": "Title 3",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 3",
+                                        "category": "MUSIC",
+                                        "creator": "Creator",
+                                        "status": "NEW"
+                             }
+                         ]
+                        """));
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser
+    void testGetEventsByCreator() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 1",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 1",
+                                        "category": "MUSIC",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 2",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 2",
+                                        "category": "ARTS",
+                                        "creator": "Creator2",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 3",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 3",
+                                        "category": "MUSIC",
+                                        "creator": "Creator2",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 4",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 4",
+                                        "category": "THEATRE",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/creator/Creator1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                             {
+                                        "title": "Title 1",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 1",
+                                        "category": "MUSIC",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                             },
+                             {
+                                        "title": "Title 4",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 4",
+                                        "category": "THEATRE",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                                }
+
+                         ]
+                        """));
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser
+    void testGetEventsByStatus() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 1",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 1",
+                                        "category": "MUSIC",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 2",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 2",
+                                        "category": "ARTS",
+                                        "creator": "Creator2",
+                                        "status": "APPROVED"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 3",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 3",
+                                        "category": "MUSIC",
+                                        "creator": "Creator2",
+                                        "status": "DECLINED"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "title": "Title 4",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 4",
+                                        "category": "THEATRE",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/status/NEW"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                             {
+                                        "title": "Title 1",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 1",
+                                        "category": "MUSIC",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                             },
+                             {
+                                        "title": "Title 4",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 4",
+                                        "category": "THEATRE",
+                                        "creator": "Creator1",
+                                        "status": "NEW"
+                             }
+                         ]
+                        """));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/status/APPROVED"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                             {
+                                        "title": "Title 2",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 2",
+                                        "category": "ARTS",
+                                        "creator": "Creator2",
+                                        "status": "APPROVED"
+                             }
+                         ]
+                        """));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/status/DECLINED"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                             {
+                                        "title": "Title 3",
+                                        "description": "Description",
+                                        "start": "2023-06-14T10:00:00Z",
+                                        "end": "2023-06-14T12:00:00Z",
+                                        "location": "Location 3",
+                                        "category": "MUSIC",
+                                        "creator": "Creator2",
+                                        "status": "DECLINED"
+                             }
+                         ]
+                        """));
+    }
+
+    @Test
+    @DirtiesContext
+    @WithMockUser
+    void testGetEventCategories() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/categories"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                             "MUSIC",
+                             "ARTS",
+                             "THEATRE",
+                             "COMEDY",
+                             "SPORTS",
+                             "EDUCATION",
+                             "OTHER"
+                         ]
+                        """));
     }
 }

--- a/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
@@ -123,7 +123,10 @@ class UserControllerTest {
                 .andExpect(content().json("""
                         {
                                         "username": "user@event.hub",
-                                        "categories": ["MUSIC", "SPORTS"]
+                                        "roles": [
+                                                "user"
+                                        ],
+                                        "preferredCategories": ["MUSIC", "SPORTS"]
                         }
                         """));
 
@@ -143,7 +146,7 @@ class UserControllerTest {
     @Test
     @DirtiesContext
     @WithMockUser
-    void logout_should_invalidate_session_and_clear_context() throws Exception {
+    void testLogout_should_invalidate_session_and_clear_context() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/user/logout")
                         .with(csrf()))
                 .andExpect(MockMvcResultMatchers.status().is(200));

--- a/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
@@ -149,7 +149,7 @@ class UserControllerTest {
     void testLogout_should_invalidate_session_and_clear_context() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/user/logout")
                         .with(csrf()))
-                .andExpect(MockMvcResultMatchers.status().is(200));
+                .andExpect(status().is(200));
         assertNull(httpSession.getAttribute("SPRING_SECURITY_CONTEXT"));
         assertNull(SecurityContextHolder.getContext().getAuthentication());
     }

--- a/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
@@ -89,7 +89,44 @@ class UserControllerTest {
     @Test
     @DirtiesContext
     @WithMockUser(username = "user@event.hub")
-    void testLogin_shouldReturn_200_and_userDTO_with_role_user() throws Exception {
+    void testLogin_shouldReturn_200_and_userDTO_with_role_user_and_list_of_preferred_categories() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/user/register")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "username": "user@event.hub",
+                                        "password": "123"
+                                }
+                                """)
+                        .with(csrf()))
+                .andExpect(status().is(201))
+                .andExpect(content().json("""
+                        {
+                                        "username": "user@event.hub",
+                                        "roles": [
+                                                "user"
+                                        ]
+                        }
+                        """))
+                .andExpect(jsonPath("$.id").isNotEmpty());
+
+        mockMvc.perform((MockMvcRequestBuilders.put("/api/user/update-preferred-categories")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                        "username": "user@event.hub",
+                                        "categories": ["MUSIC", "SPORTS"]
+                                }
+                                """)
+                        .with(csrf())))
+                .andExpect(status().is(200))
+                .andExpect(content().json("""
+                        {
+                                        "username": "user@event.hub",
+                                        "categories": ["MUSIC", "SPORTS"]
+                        }
+                        """));
+
         mockMvc.perform(MockMvcRequestBuilders.post("/api/user/login")
                         .contentType("application/json")
                         .with(csrf()))
@@ -97,7 +134,8 @@ class UserControllerTest {
                 .andExpect(content().json("""
                         {
                                         "username": "user@event.hub",
-                                        "roles": ["ROLE_USER"]
+                                        "roles": ["ROLE_USER"],
+                                        "preferredCategories": ["MUSIC", "SPORTS"]
                         }
                         """));
     }

--- a/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/UserControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;

--- a/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ class EventHubUserDetailServiceTest {
         // given
         String username = "user@event.hub";
         List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
-        EventHubUser user = new EventHubUser("1", username, "123", roles, null);
+        EventHubUser user = new EventHubUser("1", username, "123", roles, new ArrayList<>());
         when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
 
         // when

--- a/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
@@ -94,14 +94,13 @@ class EventHubUserDetailServiceTest {
         List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
         EventHubUser user = new EventHubUser("1", username, "123", roles, existingCategories);
         when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
+        EventHubUserDTO expectedUser = new EventHubUserDTO("1", username, List.of("ROLE_USER"), newCategories);
 
         // when
         EventHubUserDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(newUserPreferredCategories);
 
         // then
-        assertEquals(username, updatedUserPreferredCategories.getUsername());
-        assertEquals(newCategories, updatedUserPreferredCategories.getPreferredCategories());
-        assertEquals(newCategories, user.getPreferredCategories());
+        assertEquals(expectedUser, updatedUserPreferredCategories);
         verify(userRepository).save(user);
     }
 

--- a/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
@@ -73,14 +73,13 @@ class EventHubUserDetailServiceTest {
         List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
         EventHubUser user = new EventHubUser("1", username, "123", roles, null);
         when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
+        EventHubUserDTO expectedUser = new EventHubUserDTO("1", username, List.of("ROLE_USER"), categories);
 
         // when
         EventHubUserDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(userPreferredCategories);
 
         // then
-        assertEquals(username, updatedUserPreferredCategories.getUsername());
-        assertEquals(categories, updatedUserPreferredCategories.getPreferredCategories());
-        assertEquals(categories, user.getPreferredCategories());
+        assertEquals(expectedUser, updatedUserPreferredCategories);
         verify(userRepository).save(user);
     }
 

--- a/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
@@ -1,5 +1,6 @@
 package de.neuefische.backend.service;
 
+import de.neuefische.backend.dto.EventHubUserDTO;
 import de.neuefische.backend.dto.UserPreferredCategoriesDTO;
 import de.neuefische.backend.model.EventCategory;
 import de.neuefische.backend.model.EventHubUser;
@@ -74,11 +75,11 @@ class EventHubUserDetailServiceTest {
         when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
 
         // when
-        UserPreferredCategoriesDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(userPreferredCategories);
+        EventHubUserDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(userPreferredCategories);
 
         // then
         assertEquals(username, updatedUserPreferredCategories.getUsername());
-        assertEquals(categories, updatedUserPreferredCategories.getCategories());
+        assertEquals(categories, updatedUserPreferredCategories.getPreferredCategories());
         assertEquals(categories, user.getPreferredCategories());
         verify(userRepository).save(user);
     }
@@ -95,11 +96,11 @@ class EventHubUserDetailServiceTest {
         when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
 
         // when
-        UserPreferredCategoriesDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(newUserPreferredCategories);
+        EventHubUserDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(newUserPreferredCategories);
 
         // then
         assertEquals(username, updatedUserPreferredCategories.getUsername());
-        assertEquals(newCategories, updatedUserPreferredCategories.getCategories());
+        assertEquals(newCategories, updatedUserPreferredCategories.getPreferredCategories());
         assertEquals(newCategories, user.getPreferredCategories());
         verify(userRepository).save(user);
     }

--- a/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/EventHubUserDetailServiceTest.java
@@ -1,0 +1,107 @@
+package de.neuefische.backend.service;
+
+import de.neuefische.backend.dto.UserPreferredCategoriesDTO;
+import de.neuefische.backend.model.EventCategory;
+import de.neuefische.backend.model.EventHubUser;
+import de.neuefische.backend.repository.EventHubUserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class EventHubUserDetailServiceTest {
+
+    EventHubUserRepository userRepository = mock(EventHubUserRepository.class);
+    GenerateUUIDService generateUUIDService = mock(GenerateUUIDService.class);
+    PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+    EventHubUserDetailService eventHubUserDetailService = new EventHubUserDetailService(userRepository, passwordEncoder, generateUUIDService);
+
+    @Test
+    void testGetUserPreferredCategories_case_preferred_categories_set() {
+        // given
+        String username = "user@event.hub";
+        List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        List<EventCategory> preferredCategories = List.of(EventCategory.MUSIC, EventCategory.SPORTS);
+        EventHubUser user = new EventHubUser("1", "user@event.hub", "123", roles, preferredCategories);
+        when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
+        List<String> expectedCategories = List.of("MUSIC", "SPORTS");
+
+        // when
+        List<String> userPreferredCategories = eventHubUserDetailService.getUserPreferredCategories(username);
+
+        // then
+        assertEquals(expectedCategories, userPreferredCategories);
+    }
+
+    @Test
+    void testGetUserPreferredCategories_case_user_not_found() {
+        // given
+        String username = "user@event.hub";
+
+        // when & then
+        assertThrows(UsernameNotFoundException.class, () -> eventHubUserDetailService.getUserPreferredCategories(username));
+    }
+
+    @Test
+    void testGetUserPreferredCategories_case_no_preferred_categories_present() {
+        // given
+        String username = "user@event.hub";
+        List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        EventHubUser user = new EventHubUser("1", username, "123", roles, null);
+        when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
+
+        // when
+        List<String> userPreferredCategories = eventHubUserDetailService.getUserPreferredCategories(username);
+
+        // then
+        assertTrue(userPreferredCategories.isEmpty());
+    }
+
+    @Test
+    void testUpdateUserPreferredCategories_case_no_existing_categories() {
+        // given
+        String username = "user@event.hub";
+        List<EventCategory> categories = List.of(EventCategory.MUSIC, EventCategory.SPORTS);
+        UserPreferredCategoriesDTO userPreferredCategories = new UserPreferredCategoriesDTO(username, categories);
+        List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        EventHubUser user = new EventHubUser("1", username, "123", roles, null);
+        when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
+
+        // when
+        UserPreferredCategoriesDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(userPreferredCategories);
+
+        // then
+        assertEquals(username, updatedUserPreferredCategories.getUsername());
+        assertEquals(categories, updatedUserPreferredCategories.getCategories());
+        assertEquals(categories, user.getPreferredCategories());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void testUpdateUserPreferredCategories_case_existing_categories() {
+        // given
+        String username = "user@event.hub";
+        List<EventCategory> existingCategories = List.of(EventCategory.EDUCATION);
+        List<EventCategory> newCategories = List.of(EventCategory.MUSIC, EventCategory.SPORTS);
+        UserPreferredCategoriesDTO newUserPreferredCategories = new UserPreferredCategoriesDTO(username, newCategories);
+        List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        EventHubUser user = new EventHubUser("1", username, "123", roles, existingCategories);
+        when(userRepository.findEventHubUserByUsername(username)).thenReturn(Optional.of(user));
+
+        // when
+        UserPreferredCategoriesDTO updatedUserPreferredCategories = eventHubUserDetailService.updateUserPreferredCategories(newUserPreferredCategories);
+
+        // then
+        assertEquals(username, updatedUserPreferredCategories.getUsername());
+        assertEquals(newCategories, updatedUserPreferredCategories.getCategories());
+        assertEquals(newCategories, user.getPreferredCategories());
+        verify(userRepository).save(user);
+    }
+
+}

--- a/backend/src/test/resources/eventHubDB.users.json
+++ b/backend/src/test/resources/eventHubDB.users.json
@@ -41,6 +41,15 @@
         "role": "user"
       }
     ],
+    "preferredCategories": [
+      "MUSIC",
+      "ARTS",
+      "THEATRE",
+      "COMEDY",
+      "SPORTS",
+      "EDUCATION",
+      "OTHER"
+    ],
     "_class": "de.neuefische.backend.model.EventHubUser"
   },
   {
@@ -61,6 +70,131 @@
     "roles": [
       {
         "role": "organizer"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "7",
+    "username": "user2@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "MUSIC"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "8",
+    "username": "user3@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "ARTS"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "9",
+    "username": "user4@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "THEATRE"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "10",
+    "username": "user5@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "COMEDY"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "11",
+    "username": "user6@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "SPORTS"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "12",
+    "username": "user7@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "EDUCATION"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "13",
+    "username": "user8@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "OTHER"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "14",
+    "username": "user9@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "preferredCategories": [
+      "MUSIC",
+      "COMEDY",
+      "OTHER"
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "15",
+    "username": "user10@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
       }
     ],
     "_class": "de.neuefische.backend.model.EventHubUser"

--- a/backend/src/test/resources/eventHubDB.users.json
+++ b/backend/src/test/resources/eventHubDB.users.json
@@ -1,44 +1,68 @@
-[{
-  "_id": "1",
-  "username": "admin@event.hub",
-  "password": "$argon2id$v=19$m=16384,t=2,p=1$Z0hpxZ8UBgDC6QLxG2QtTA$SDZZlK2nbHCWBHFgHu5TJcD0jjRQ7PWDzPXJRhIquFY",
-  "roles": [
-    {
-      "role": "admin"
-    }
-  ],
-  "_class": "de.neuefische.backend.model.EventHubUser"
-},
-{
-  "_id": "2",
-  "username": "organizer@event.hub",
-  "password": "$argon2id$v=19$m=16384,t=2,p=1$FwD7nPZvnbxUzPMb94sZxg$qdZUaR/OMZ8aQKEJbPUZxV/3wOk77uFpaayfYtIuo/Y",
-  "roles": [
-    {
-      "role": "organizer"
-    }
-  ],
-  "_class": "de.neuefische.backend.model.EventHubUser"
-},
-{
-  "_id": "3",
-  "username": "editor@event.hub",
-  "password": "$argon2id$v=19$m=16384,t=2,p=1$FZWd9zGHHzUe3u7wIAEXWw$V4KxHAocc+whBXWSc81N6kVVoy1h0tkXvFnFs4M2UtM",
-  "roles": [
-    {
-      "role": "editor"
-    }
-  ],
-  "_class": "de.neuefische.backend.model.EventHubUser"
-},
-{
-  "_id": "4",
-  "username": "user@event.hub",
-  "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
-  "roles": [
-    {
-      "role": "user"
-    }
-  ],
-  "_class": "de.neuefische.backend.model.EventHubUser"
-}]
+[
+  {
+    "_id": "1",
+    "username": "admin@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$Z0hpxZ8UBgDC6QLxG2QtTA$SDZZlK2nbHCWBHFgHu5TJcD0jjRQ7PWDzPXJRhIquFY",
+    "roles": [
+      {
+        "role": "admin"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "2",
+    "username": "organizer@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$FwD7nPZvnbxUzPMb94sZxg$qdZUaR/OMZ8aQKEJbPUZxV/3wOk77uFpaayfYtIuo/Y",
+    "roles": [
+      {
+        "role": "organizer"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "3",
+    "username": "editor@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$FZWd9zGHHzUe3u7wIAEXWw$V4KxHAocc+whBXWSc81N6kVVoy1h0tkXvFnFs4M2UtM",
+    "roles": [
+      {
+        "role": "editor"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "4",
+    "username": "user@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$UC97G/GN9fW91opj9aXugA$TPb+IIzn5R34fEqyXjBIodjo18o6Fz68Y3B/s/+gh44",
+    "roles": [
+      {
+        "role": "user"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "5",
+    "username": "organizer2@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$FwD7nPZvnbxUzPMb94sZxg$qdZUaR/OMZ8aQKEJbPUZxV/3wOk77uFpaayfYtIuo/Y",
+    "roles": [
+      {
+        "role": "organizer"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  },
+  {
+    "_id": "6",
+    "username": "organizer3@event.hub",
+    "password": "$argon2id$v=19$m=16384,t=2,p=1$FwD7nPZvnbxUzPMb94sZxg$qdZUaR/OMZ8aQKEJbPUZxV/3wOk77uFpaayfYtIuo/Y",
+    "roles": [
+      {
+        "role": "organizer"
+      }
+    ],
+    "_class": "de.neuefische.backend.model.EventHubUser"
+  }
+]

--- a/backend/src/test/resources/events.json
+++ b/backend/src/test/resources/events.json
@@ -6,8 +6,8 @@
     "end": "2023-06-25T23:00:00Z",
     "location": "Knoops Park",
     "category": "MUSIC",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer@event.hub",
+    "status": "APPROVED",
     "source": "https://www.bremen.de/kultur/veranstaltungen/highlights/sommer-in-lesmona",
     "imageUrl": "https://media.istockphoto.com/id/523871055/de/foto/weibliche-violinists-vorbereitung-klassisches-konzert.jpg?s=2048x2048&w=is&k=20&c=tMs-dzkkJe08obnlTWlJAl_jkjwYsOBnCIZ0Tc5f05M="
   },
@@ -18,8 +18,8 @@
     "end": "2023-06-24T23:59:00Z",
     "location": "Universität Bremen",
     "category": "EDUCATION",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer@event.hub",
+    "status": "DECLINED",
     "source": "https://www.bremen.de/veranstaltung/open-campus-2023#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/3db/open-and-read-1413658.jpg"
   },
@@ -30,7 +30,7 @@
     "end": "2023-07-01T23:00:00Z",
     "location": "Marktplatz Bremen",
     "category": "MUSIC",
-    "creator": "Peter Mustermann",
+    "creator": "organizer2@event.hub",
     "status": "NEW",
     "source": "https://www.bremen.de/veranstaltung/hoeg-citysommerfest-das-open-air-in-bremen-city#/",
     "imageUrl": "https://media.istockphoto.com/id/1370212283/de/foto/menschenmenge-feiert-beim-live-konzert.jpg?s=2048x2048&w=is&k=20&c=NBFD8MQXkDN6ksi0JtTitMbbRpKXYJ14cFQSmNdoPKY="
@@ -42,7 +42,7 @@
     "end": "2023-07-07T22:30:00Z",
     "location": "Seebühne Bremen; AG-Weser-Str. 3, 28237 Bremen",
     "category": "MUSIC",
-    "creator": "Peter Mustermann",
+    "creator": "organizer3@event.hub",
     "status": "NEW",
     "source": "https://www.bremen.de/veranstaltung/david-garrett-trio-iconic-tour-2023-seebuhne-bremen-2023#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/951/violin-1415547.jpg"
@@ -54,8 +54,8 @@
     "end": "2023-06-21T19:00:00Z",
     "location": "LiteraturKeller",
     "category": "THEATRE",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer3@event.hub",
+    "status": "DECLINED",
     "source": "https://www.bremen.de/veranstaltung/faust-3#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/a5f/lonely-chair-1618011.jpg"
   },
@@ -66,8 +66,8 @@
     "end": "2023-06-23T22:00:00Z",
     "location": "Theatersaal Universität Bremen",
     "category": "THEATRE",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer3@event.hub",
+    "status": "APPROVED",
     "source": "https://www.bremen.de/veranstaltung/geschlossene-gesellschaft#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/1ef/red-curtain-1203512.jpg"
   },
@@ -78,8 +78,8 @@
     "end": "2023-06-21T22:00:00Z",
     "location": "Hotel Strandlust",
     "category": "SPORTS",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer3@event.hub",
+    "status": "DECLINED",
     "source": "https://www.bremen.de/veranstaltung/international-yoga-day-2023-yoga-an-der-weser#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/ffe/meditation-1306234.jpg"
   },
@@ -103,7 +103,7 @@
     "location": "Unser Lieben Frauen Kirchhof",
     "category": "SPORTS",
     "creator": "Peter Mustermann",
-    "status": "NEW",
+    "status": "APPROVED",
     "source": "https://www.bremen.de/veranstaltung/sportscheck-night-run-bremen#/",
     "imageUrl": "https://media.istockphoto.com/id/859932820/de/foto/mann-l%C3%A4uft.jpg?s=2048x2048&w=is&k=20&c=Qztra5Z0pyg56qZ2QNChYXfjHeOlscSf1V0QlHvDxeA="
   },
@@ -114,7 +114,7 @@
     "end": "2023-11-05T00:00:00Z",
     "location": "Übersee-Museum",
     "category": "ARTS",
-    "creator": "Peter Mustermann",
+    "creator": "organizer2@event.hub",
     "status": "NEW",
     "source": "https://www.bremen.de/veranstaltung/american-dreams-bilder-aus-den-usa#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/d26/vintage-camera-1-1293857.jpg"
@@ -126,8 +126,8 @@
     "end": "2023-07-16T18:00:00Z",
     "location": "Overbeck-Museum",
     "category": "ARTS",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer2@event.hub",
+    "status": "APPROVED",
     "source": "https://www.bremen.de/veranstaltung/auf-sicht-die-norddeutschen-realisten-malen-in-bremen#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/a0b/artist-palette-1172456.jpg"
   },
@@ -138,8 +138,8 @@
     "end": "2023-06-29T22:15:00Z",
     "location": "Halle 7",
     "category": "COMEDY",
-    "creator": "Peter Mustermann",
-    "status": "NEW",
+    "creator": "organizer@event.hub",
+    "status": "DECLINED",
     "source": "https://www.bremen.de/veranstaltung/luke-mockridge#/",
     "imageUrl": "https://images.freeimages.com/images/large-previews/325/april-fool-1443289.jpg"
   }

--- a/backend/src/test/resources/events.json
+++ b/backend/src/test/resources/events.json
@@ -1,9 +1,10 @@
 [
   {
+    "_id": "7ec58bdb-3160-400b-979b-25e30e0024f7",
     "title": "Sommer in Lesmona",
     "description": "Klassik Open-Air",
-    "start": "2023-06-23T21:00:00Z",
-    "end": "2023-06-25T23:00:00Z",
+    "start": "2023-06-23T21:00:00.000+00:00",
+    "end": "2023-06-25T23:00:00.000+00:00",
     "location": "Knoops Park",
     "category": "MUSIC",
     "creator": "organizer@event.hub",
@@ -12,10 +13,11 @@
     "imageUrl": "https://media.istockphoto.com/id/523871055/de/foto/weibliche-violinists-vorbereitung-klassisches-konzert.jpg?s=2048x2048&w=is&k=20&c=tMs-dzkkJe08obnlTWlJAl_jkjwYsOBnCIZ0Tc5f05M="
   },
   {
+    "_id": "63e84a86-f8e2-4763-adff-15ace5eaa864",
     "title": "OPEN CAMPUS",
     "description": "WELTEN ÖFFNEN - WISSEN TEILEN; Fachbereiche stellen sich vor",
-    "start": "2023-06-23T18:00:00Z",
-    "end": "2023-06-24T23:59:00Z",
+    "start": "2023-06-23T18:00:00.000+00:00",
+    "end": "2023-06-24T23:59:00.000+00:00",
     "location": "Universität Bremen",
     "category": "EDUCATION",
     "creator": "organizer@event.hub",
@@ -24,10 +26,11 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/3db/open-and-read-1413658.jpg"
   },
   {
+    "_id": "8f55d410-7241-49f9-b625-d3b75115eab0",
     "title": "HOEG CitySommerFest",
     "description": "Live-Musik, Genuss und Kulturaktionen in Bremen City",
-    "start": "2023-06-29T14:00:00Z",
-    "end": "2023-07-01T23:00:00Z",
+    "start": "2023-06-29T14:00:00.000+00:00",
+    "end": "2023-07-01T23:00:00.000+00:00",
     "location": "Marktplatz Bremen",
     "category": "MUSIC",
     "creator": "organizer2@event.hub",
@@ -36,10 +39,11 @@
     "imageUrl": "https://media.istockphoto.com/id/1370212283/de/foto/menschenmenge-feiert-beim-live-konzert.jpg?s=2048x2048&w=is&k=20&c=NBFD8MQXkDN6ksi0JtTitMbbRpKXYJ14cFQSmNdoPKY="
   },
   {
+    "_id": "7c9c0c48-bbcc-42c7-9d30-57820e013628",
     "title": "David Garrett Trio Iconic Tour",
     "description": "Hommage an die großen Geiger des Goldenen Zeitalters",
-    "start": "2023-07-07T20:30:00Z",
-    "end": "2023-07-07T22:30:00Z",
+    "start": "2023-07-07T20:30:00.000+00:00",
+    "end": "2023-07-07T22:30:00.000+00:00",
     "location": "Seebühne Bremen; AG-Weser-Str. 3, 28237 Bremen",
     "category": "MUSIC",
     "creator": "organizer3@event.hub",
@@ -48,10 +52,11 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/951/violin-1415547.jpg"
   },
   {
+    "_id": "7b434880-f193-41e2-bc33-39c22cae02de",
     "title": "Faust",
     "description": "Der Klassiker als rasantes Solo in maximal 40 Minuten",
-    "start": "2023-06-19T18:00:00Z",
-    "end": "2023-06-21T19:00:00Z",
+    "start": "2023-06-19T18:00:00.000+00:00",
+    "end": "2023-06-21T19:00:00.000+00:00",
     "location": "LiteraturKeller",
     "category": "THEATRE",
     "creator": "organizer3@event.hub",
@@ -60,10 +65,11 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/a5f/lonely-chair-1618011.jpg"
   },
   {
+    "_id": "f9a795dd-38c6-47b0-af44-158b46d88b30",
     "title": "Geschlossene Gesellschaft",
     "description": "Theaterstück von Jean-Paul Sartre, Inszenierung von Franz Eggstein",
-    "start": "2023-06-22T20:00:00Z",
-    "end": "2023-06-23T22:00:00Z",
+    "start": "2023-06-22T20:00:00.000+00:00",
+    "end": "2023-06-23T22:00:00.000+00:00",
     "location": "Theatersaal Universität Bremen",
     "category": "THEATRE",
     "creator": "organizer3@event.hub",
@@ -72,10 +78,11 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/1ef/red-curtain-1203512.jpg"
   },
   {
+    "_id": "2468c842-4362-456f-ba79-ef2f43e3edfb",
     "title": "International Yoga Day 2023",
     "description": "Yoga an der Weser",
-    "start": "2023-06-21T18:00:00Z",
-    "end": "2023-06-21T22:00:00Z",
+    "start": "2023-06-21T18:00:00.000+00:00",
+    "end": "2023-06-21T22:00:00.000+00:00",
     "location": "Hotel Strandlust",
     "category": "SPORTS",
     "creator": "organizer3@event.hub",
@@ -84,34 +91,37 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/ffe/meditation-1306234.jpg"
   },
   {
+    "_id": "9aca5ddb-8264-45d9-8180-1826d076e49a",
     "title": "Stand-Up-Paddling - Schnupperkurs",
     "description": "Vermittlung der Grundlagen des Stand-Up-Paddlings in Theorie und Praxis",
-    "start": "2023-06-22T17:30:00Z",
-    "end": "2023-06-22T19:45:00Z",
+    "start": "2023-06-22T17:30:00.000+00:00",
+    "end": "2023-06-22T19:45:00.000+00:00",
     "location": "Ohlenstedter Quellsee; Osterholz-Scharmbeck",
     "category": "SPORTS",
-    "creator": "Peter Mustermann",
+    "creator": "organizer2@event.hub",
     "status": "NEW",
     "source": "https://www.bremen.de/veranstaltung/stand-up-paddling-schnupperkurs#/",
     "imageUrl": "https://media.istockphoto.com/id/1336264959/de/foto/paddelborading.jpg?s=2048x2048&w=is&k=20&c=9A8YKLtC1TOweucXWLIYExjXWddIlf-rti2TedMruEQ="
   },
   {
+    "_id": "9a48671a-c646-4d5e-bfd7-04bd1faca712",
     "title": "SportScheck Night RUN Bremen",
     "description": "Bremer Nachtlauf",
-    "start": "2023-06-23T20:00:00Z",
-    "end": "2023-06-23T23:59:00Z",
+    "start": "2023-06-23T20:00:00.000+00:00",
+    "end": "2023-06-23T23:59:00.000+00:00",
     "location": "Unser Lieben Frauen Kirchhof",
     "category": "SPORTS",
-    "creator": "Peter Mustermann",
+    "creator": "organizer@event.hub",
     "status": "APPROVED",
     "source": "https://www.bremen.de/veranstaltung/sportscheck-night-run-bremen#/",
     "imageUrl": "https://media.istockphoto.com/id/859932820/de/foto/mann-l%C3%A4uft.jpg?s=2048x2048&w=is&k=20&c=Qztra5Z0pyg56qZ2QNChYXfjHeOlscSf1V0QlHvDxeA="
   },
   {
+    "_id": "7087df26-e2da-430c-a7be-4012cebf6d1d",
     "title": "American Dreams - Bilder aus den USA",
     "description": "Fotoausstellung auf den Spuren des American Dreams",
-    "start": "2023-06-14T00:00:00Z",
-    "end": "2023-11-05T00:00:00Z",
+    "start": "2023-06-14T00:00:00.000+00:00",
+    "end": "2023-11-05T00:00:00.000+00:00",
     "location": "Übersee-Museum",
     "category": "ARTS",
     "creator": "organizer2@event.hub",
@@ -120,10 +130,11 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/d26/vintage-camera-1-1293857.jpg"
   },
   {
+    "_id": "6d83fc42-d69a-41de-8c86-75edaed13c9a",
     "title": "Auf Sicht - Die Norddeutschen Realisten malen in Bremen",
     "description": "Nordische Landschaften und maritime Themen",
-    "start": "2023-06-14T11:00:00Z",
-    "end": "2023-07-16T18:00:00Z",
+    "start": "2023-06-14T11:00:00.000+00:00",
+    "end": "2023-07-16T18:00:00.000+00:00",
     "location": "Overbeck-Museum",
     "category": "ARTS",
     "creator": "organizer2@event.hub",
@@ -132,10 +143,11 @@
     "imageUrl": "https://images.freeimages.com/images/large-previews/a0b/artist-palette-1172456.jpg"
   },
   {
+    "_id": "3cdc8922-d8ec-4b6b-9e15-c5aac02c098e",
     "title": "Luke Mockridge",
     "description": "TRIPPY Tour 2023",
-    "start": "2023-06-29T20:00:00Z",
-    "end": "2023-06-29T22:15:00Z",
+    "start": "2023-06-29T20:00:00.000+00:00",
+    "end": "2023-06-29T22:15:00.000+00:00",
     "location": "Halle 7",
     "category": "COMEDY",
     "creator": "organizer@event.hub",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.12.1",
         "react-scripts": "5.0.1",
+        "react-toastify": "^9.1.3",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }
@@ -5722,6 +5723,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14419,6 +14428,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,10 +90,10 @@ function App() {
                     <Route path={"/"} element={<Home login={login} register={register}/>}/>
 
                     <Route element={<ProtectedRoutesUser user={user}/>}>
-                        {user && <Route path="/gallery" element={<EventGallery user={user} events={events} getAllEvents={getAllEvents} getEventsByCategory={getEventsByCategory}/>}/>}
-                        {user && <Route path="/categorySelection"
+                        <Route path="/gallery" element={<EventGallery user={user} events={events} getAllEvents={getAllEvents} getEventsByCategory={getEventsByCategory}/>}/>
+                        <Route path="/categorySelection"
                                         element={<PreferredEventCategorySelection user={user} categories={categories}
-                                                                                  updateUserPreferredCategories={updateUserPreferredCategories}/>}/>}
+                                                                                  updateUserPreferredCategories={updateUserPreferredCategories}/>}/>
                     </Route>
 
                     <Route element={<ProtectedRoutesAdminOnly user={user}/>}>
@@ -101,10 +101,10 @@ function App() {
                     </Route>
 
                     <Route element={<ProtectedRoutesAdminAndOrganizer user={user}/>}>
-                        {user && <Route path="/add" element={<AddEvent user={user} events={events}
+                        <Route path="/add" element={<AddEvent user={user} events={events}
                                                                        getEventsByCreator={getEventsByCreator}
                                                                        saveEvent={saveEvent} updateEvent={updateEvent}
-                                                                       deleteEvent={deleteEvent}/>}/>}
+                                                                       deleteEvent={deleteEvent}/>}/>
                     </Route>
 
                     <Route element={<ProtectedRoutesAdminAndEditor user={user}/>}>

--- a/frontend/src/components/AddEvent.css
+++ b/frontend/src/components/AddEvent.css
@@ -1,0 +1,46 @@
+.list-item {
+    background-color: #f2f2f2;
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.list-item .buttons .button {
+    margin-left: 10px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+label {
+    margin-bottom: 0.5em;
+}
+
+input,
+textarea,
+select {
+    padding: 0.5em;
+    margin-bottom: 1em;
+}
+
+button {
+    margin: 0.5em;
+    padding: 0.5em 1em;
+    background-color: gray;
+    color: white;
+    border: none;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #45a049;
+}
+
+button:disabled {
+    background-color: #cccccc;
+    cursor: not-allowed;
+}

--- a/frontend/src/components/AddEvent.tsx
+++ b/frontend/src/components/AddEvent.tsx
@@ -59,13 +59,15 @@ function AddEvent(props: Props) {
             <h1>My events</h1>
             <h2>Logged in user: {props.user?.username}</h2>
             <h4>(only organizers and administrators can see this)</h4>
-            <EventForm
-                user={props.user}
-                event={selectedEvent}
-                isFormVisible={isFormVisible}
-                onSave={onSaveHandler}
-                onClose={onCloseHandler}
-            />
+            {selectedEvent && (
+                <EventForm
+                    user={props.user}
+                    event={selectedEvent}
+                    isFormVisible={isFormVisible}
+                    onSave={onSaveHandler}
+                    onClose={onCloseHandler}
+                />
+            )}
             <ul>
                 {props.events.map((currentEvent: EventModel) => (
                     <li className="list-item" key={currentEvent.id}>

--- a/frontend/src/components/AddEvent.tsx
+++ b/frontend/src/components/AddEvent.tsx
@@ -26,7 +26,6 @@ function AddEvent(props: Props) {
     }, [props.user?.username]);
 
     function onDeleteHandler(event: EventModel) {
-        console.log("Delete button clicked");
         props.deleteEvent(event, () => {
             if (props.user) {
                 props.getEventsByCreator(props.user.username);
@@ -35,7 +34,6 @@ function AddEvent(props: Props) {
     }
 
     function onEditHandler(event: EventModel) {
-        console.log("Edit button clicked");
         setSelectedEvent(event);
         setIsFormVisible(true);
     }

--- a/frontend/src/components/AddEvent.tsx
+++ b/frontend/src/components/AddEvent.tsx
@@ -5,7 +5,7 @@ import './AddEvent.css';
 import EventForm from "./EventForm";
 
 type Props = {
-    user: User,
+    user: User | undefined,
     events: EventModel[],
     getEventsByCreator: (creator: string) => void,
     saveEvent: (event: EventModel) => void,
@@ -19,13 +19,19 @@ function AddEvent(props: Props) {
     const [selectedEvent, setSelectedEvent] = useState<EventModel | undefined>(undefined);
 
     useEffect(() => {
-        props.getEventsByCreator(props.user.username);
+        if (props.user) {
+            props.getEventsByCreator(props.user.username);
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.user.username]);
+    }, [props.user?.username]);
 
     function onDeleteHandler(event: EventModel) {
         console.log("Delete button clicked");
-        props.deleteEvent(event, () => props.getEventsByCreator(props.user.username));
+        props.deleteEvent(event, () => {
+            if (props.user) {
+                props.getEventsByCreator(props.user.username);
+            }
+        });
     }
 
     function onEditHandler(event: EventModel) {
@@ -51,7 +57,7 @@ function AddEvent(props: Props) {
     return (
         <div>
             <h1>My events</h1>
-            <h2>Logged in user: {props.user.username}</h2>
+            <h2>Logged in user: {props.user?.username}</h2>
             <h4>(only organizers and administrators can see this)</h4>
             <EventForm
                 user={props.user}

--- a/frontend/src/components/AddEvent.tsx
+++ b/frontend/src/components/AddEvent.tsx
@@ -1,16 +1,80 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {EventModel} from "../model/EventModel";
+import {User} from "../model/User";
+import './AddEvent.css';
+import EventForm from "./EventForm";
 
 type Props = {
-    events:EventModel[]
+    user: User,
+    events: EventModel[],
+    getEventsByCreator: (creator: string) => void,
+    saveEvent: (event: EventModel) => void,
+    updateEvent: (id: string, event: EventModel) => void,
+    deleteEvent: (event: EventModel, callback?: () => void) => void
 }
 
-function AddEvent(props:Props) {
+function AddEvent(props: Props) {
+
+    const [isFormVisible, setIsFormVisible] = useState(false);
+    const [selectedEvent, setSelectedEvent] = useState<EventModel | undefined>(undefined);
+
+    useEffect(() => {
+        props.getEventsByCreator(props.user.username);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.user.username]);
+
+    function onDeleteHandler(event: EventModel) {
+        console.log("Delete button clicked");
+        props.deleteEvent(event, () => props.getEventsByCreator(props.user.username));
+    }
+
+    function onEditHandler(event: EventModel) {
+        console.log("Edit button clicked");
+        setSelectedEvent(event);
+        setIsFormVisible(true);
+    }
+
+    function onSaveHandler(event: EventModel) {
+        if (selectedEvent) {
+            props.updateEvent(selectedEvent.id, event);
+        } else {
+            props.saveEvent(event);
+        }
+        setIsFormVisible(false);
+    }
+
+    function onCloseHandler() {
+        setSelectedEvent(undefined);
+        setIsFormVisible(false);
+    }
+
     return (
         <div>
-            <h1>ADD EVENTS VIEW</h1>
-            <h2>only organizers and administrators can see this</h2>
-            {props.events.map((currentEvent:EventModel) => {return <li key={currentEvent.id}>{currentEvent.title}</li>})}
+            <h1>My events</h1>
+            <h2>Logged in user: {props.user.username}</h2>
+            <h4>(only organizers and administrators can see this)</h4>
+            <EventForm
+                user={props.user}
+                event={selectedEvent}
+                isFormVisible={isFormVisible}
+                onSave={onSaveHandler}
+                onClose={onCloseHandler}
+            />
+            <ul>
+                {props.events.map((currentEvent: EventModel) => (
+                    <li className="list-item" key={currentEvent.id}>
+                        {currentEvent.title}
+                        <div className="buttons">
+                            <button className="button" onClick={() => onEditHandler(currentEvent)}>
+                                Edit
+                            </button>
+                            <button className="button" onClick={() => onDeleteHandler(currentEvent)}>
+                                Delete
+                            </button>
+                        </div>
+                    </li>
+                ))}
+            </ul>
         </div>
     );
 }

--- a/frontend/src/components/ApproveEvent.tsx
+++ b/frontend/src/components/ApproveEvent.tsx
@@ -1,16 +1,50 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {EventModel} from "../model/EventModel";
+import {User} from "../model/User";
+import './AddEvent.css';
 
 type Props = {
-    events:EventModel[]
+    user: User,
+    events: EventModel[],
+    getEventsByStatus: () => void,
+    saveEvent: (event: EventModel) => void
+    updateEvent: (id: string, event: EventModel) => void
 }
 
-function ApproveEvent(props:Props) {
+function ApproveEvent(props: Props) {
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(props.getEventsByStatus, []);
+
+    const onApproveHandler = (event: EventModel) => {
+        console.log('Approve button clicked');
+        const approvedEvent: EventModel = {
+            ...event,
+            status: 'APPROVED'
+        };
+        props.updateEvent(event.id, approvedEvent);
+    };
+
+    function onDetailsHandler() {
+        console.log("Details button clicked");
+    }
+
     return (
         <div>
-            <h1>APPROVE EVENTS VIEW</h1>
-            <h2>only editors and administrators can see this</h2>
-            {props.events.map((currentEvent:EventModel) => {return <li key={currentEvent.id}>{currentEvent.title}</li>})}
+            <h1>New events</h1>
+            <h2>Logged in user: {props.user.username}</h2>
+            <h4>(only editors and administrators can see this)</h4>
+            <ul>
+                {props.events.map((currentEvent: EventModel) => (
+                    <li className="list-item" key={currentEvent.id}>
+                        {currentEvent.title}
+                        <div className="buttons">
+                            <button className="button" onClick={onDetailsHandler}>Details</button>
+                            <button className="button" onClick={() => onApproveHandler(currentEvent)}>Approve</button>
+                        </div>
+                    </li>
+                ))}
+            </ul>
         </div>
     );
 }

--- a/frontend/src/components/ApproveEvent.tsx
+++ b/frontend/src/components/ApproveEvent.tsx
@@ -17,7 +17,6 @@ function ApproveEvent(props: Props) {
     useEffect(props.getEventsByStatus, []);
 
     const onApproveHandler = (event: EventModel) => {
-        console.log('Approve button clicked');
         const approvedEvent: EventModel = {
             ...event,
             status: 'APPROVED'
@@ -26,7 +25,6 @@ function ApproveEvent(props: Props) {
     };
 
     function onDetailsHandler() {
-        console.log("Details button clicked");
     }
 
     return (

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -55,7 +55,7 @@ function EventForm(props: Props) {
             end: new Date(startDate + "T" + startTime + ":00"),
             location: location,
             category: category,
-            creator: props.user?.username || "",
+            creator: props.user?.username ?? "",
             status: "NEW",
             source: source,
             imageUrl: ""

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -1,0 +1,161 @@
+import React, {ChangeEvent, FormEvent, useEffect, useState} from 'react';
+import {EventModel} from "../model/EventModel";
+import {User} from "../model/User";
+
+type Props = {
+    user: User,
+    event: EventModel | undefined,
+    isFormVisible: boolean,
+    onSave: (event: EventModel) => void,
+    onClose: () => void;
+}
+
+function EventForm(props: Props) {
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [startDate, setStartDate] = useState("");
+    const [startTime, setStartTime] = useState("");
+    const [location, setLocation] = useState("");
+    const [category, setCategory] = useState("");
+    const [source, setSource] = useState("");
+
+    useEffect(() => {
+        if (props.event) {
+            const { title, description, startDate, startTime, location, category, source } = props.event;
+            setTitle(title);
+            setDescription(description);
+            setStartDate(startDate);
+            setStartTime(startTime);
+            setLocation(location);
+            setCategory(category);
+            setSource(source);
+        } else {
+            setTitle('');
+            setDescription('');
+            setStartDate('');
+            setStartTime('');
+            setLocation('');
+            setCategory('');
+            setSource('');
+        }
+    }, [props.event]);
+
+    function onSubmitHandler(e: FormEvent<HTMLFormElement>) {
+        console.log("Submit button clicked");
+
+        e.preventDefault();
+
+        const event: EventModel = {
+            id: "",
+            title: title,
+            description: description,
+            start: new Date(startDate + "T" + startTime + ":00"),
+            startDate: startDate,
+            startTime: startTime,
+            end: new Date(startDate + "T" + startTime + ":00"),
+            location: location,
+            category: category,
+            creator: props.user.username,
+            status: "NEW",
+            source: source,
+            imageUrl: ""
+        };
+
+        props.onSave(event);
+        props.onClose();
+    }
+
+    function onChangeHandlerTitle(e: ChangeEvent<HTMLInputElement>) {
+        setTitle(e.target.value)
+    }
+
+    function onChangeHandlerDescription(e: ChangeEvent<HTMLTextAreaElement>) {
+        setDescription(e.target.value)
+    }
+
+    function onChangeHandlerStartDate(e: ChangeEvent<HTMLInputElement>) {
+        setStartDate(e.target.value)
+    }
+
+    function onChangeHandlerStartTime(e: ChangeEvent<HTMLInputElement>) {
+        setStartTime(e.target.value)
+    }
+
+    function onChangeHandlerLocation(e: ChangeEvent<HTMLInputElement>) {
+        setLocation(e.target.value)
+    }
+
+    function onChangeHandlerCategory(e: ChangeEvent<HTMLSelectElement>) {
+        setCategory(e.target.value)
+    }
+
+    function onChangeHandlerSource(e: ChangeEvent<HTMLInputElement>) {
+        setSource(e.target.value)
+    }
+
+    return (
+        <div className="modal">
+            <div className="modal-content">
+                <h3>{props.event ? 'Edit Event' : 'Add Event'}</h3>
+                <form onSubmit={onSubmitHandler}>
+                    <div>
+                        <label htmlFor="title">Title </label>
+                        <input type="text" id="title" name="title" value={title} onChange={onChangeHandlerTitle}
+                               required/>
+                    </div>
+                    <div>
+                        <label htmlFor="description">Description</label>
+                        <textarea id="description" name="description" value={description}
+                                  onChange={onChangeHandlerDescription} rows={4} cols={50} required>
+                    </textarea>
+                    </div>
+                    <div>
+                        <label htmlFor="startDate">Date </label>
+                        <input type="date" id="startDate" name="startDate" value={startDate}
+                               onChange={onChangeHandlerStartDate} required/>
+                    </div>
+                    <div>
+                        <label htmlFor="startTime">Time </label>
+                        <input type="time" id="startTime" name="startTime" value={startTime}
+                               onChange={onChangeHandlerStartTime} required/>
+                    </div>
+                    <div>
+                        <label htmlFor="location">Location </label>
+                        <input type="text" id="location" name="location" value={location}
+                               onChange={onChangeHandlerLocation} required/>
+                    </div>
+                    <div>
+                        <label htmlFor="category">Category </label>
+                        <select id="category" name="category" value={category} onChange={onChangeHandlerCategory}
+                                required>
+                            <option value="OTHER">Other</option>
+                            <option value="MUSIC">Music</option>
+                            <option value="ARTS">Arts</option>
+                            <option value="THEATRE">Theatre</option>
+                            <option value="COMEDY">Comedy</option>
+                            <option value="SPORTS">Sports</option>
+                            <option value="EDUCATION">Education</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label htmlFor="source">Source </label>
+                        <input type="url" value={source} onChange={onChangeHandlerSource} required/>
+                    </div>
+                    <div>
+                        <label htmlFor="image">Image </label>
+                        <input type="file" id="image" name="image"/>
+                    </div>
+
+                    <div>
+                        <button type="submit">{props.event ? 'Save' : 'Add'}</button>
+                        <button type="button" onClick={props.onClose}>
+                            Close
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}
+
+export default EventForm;

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -3,7 +3,7 @@ import {EventModel} from "../model/EventModel";
 import {User} from "../model/User";
 
 type Props = {
-    user: User,
+    user: User | undefined,
     event: EventModel | undefined,
     isFormVisible: boolean,
     onSave: (event: EventModel) => void,
@@ -22,13 +22,13 @@ function EventForm(props: Props) {
     useEffect(() => {
         if (props.event) {
             const { title, description, startDate, startTime, location, category, source } = props.event;
-            setTitle(title);
-            setDescription(description);
-            setStartDate(startDate);
-            setStartTime(startTime);
-            setLocation(location);
-            setCategory(category);
-            setSource(source);
+            setTitle(title || '');
+            setDescription(description || '');
+            setStartDate(startDate || '');
+            setStartTime(startTime || '');
+            setLocation(location || '');
+            setCategory(category || '');
+            setSource(source || '');
         } else {
             setTitle('');
             setDescription('');
@@ -55,7 +55,7 @@ function EventForm(props: Props) {
             end: new Date(startDate + "T" + startTime + ":00"),
             location: location,
             category: category,
-            creator: props.user.username,
+            creator: props.user?.username || "",
             status: "NEW",
             source: source,
             imageUrl: ""

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -73,14 +73,6 @@ function EventForm(props: Props) {
         setDescription(e.target.value)
     }
 
-    function onChangeHandlerStartDate(e: ChangeEvent<HTMLInputElement>) {
-        setStartDate(e.target.value)
-    }
-
-    function onChangeHandlerStartTime(e: ChangeEvent<HTMLInputElement>) {
-        setStartTime(e.target.value)
-    }
-
     function onChangeHandlerLocation(e: ChangeEvent<HTMLInputElement>) {
         setLocation(e.target.value)
     }

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -110,16 +110,6 @@ function EventForm(props: Props) {
                     </textarea>
                     </div>
                     <div>
-                        <label htmlFor="startDate">Date </label>
-                        <input type="date" id="startDate" name="startDate" value={startDate}
-                               onChange={onChangeHandlerStartDate} required/>
-                    </div>
-                    <div>
-                        <label htmlFor="startTime">Time </label>
-                        <input type="time" id="startTime" name="startTime" value={startTime}
-                               onChange={onChangeHandlerStartTime} required/>
-                    </div>
-                    <div>
                         <label htmlFor="location">Location </label>
                         <input type="text" id="location" name="location" value={location}
                                onChange={onChangeHandlerLocation} required/>

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -21,7 +21,7 @@ function EventForm(props: Props) {
 
     useEffect(() => {
         if (props.event) {
-            const { title, description, startDate, startTime, location, category, source } = props.event;
+            const {title, description, startDate, startTime, location, category, source} = props.event;
             setTitle(title || '');
             setDescription(description || '');
             setStartDate(startDate || '');
@@ -141,11 +141,6 @@ function EventForm(props: Props) {
                         <label htmlFor="source">Source </label>
                         <input type="url" value={source} onChange={onChangeHandlerSource} required/>
                     </div>
-                    <div>
-                        <label htmlFor="image">Image </label>
-                        <input type="file" id="image" name="image"/>
-                    </div>
-
                     <div>
                         <button type="submit">{props.event ? 'Save' : 'Add'}</button>
                         <button type="button" onClick={props.onClose}>

--- a/frontend/src/components/EventGallery.tsx
+++ b/frontend/src/components/EventGallery.tsx
@@ -2,19 +2,40 @@ import React from 'react';
 import {EventModel} from "../model/EventModel";
 import EventCard from "./EventCard";
 import './EventGallery.css';
+import {User} from "../model/User";
 
-type Props ={
-    events:EventModel[]
+type Props = {
+    user: User,
+    events: EventModel[],
+    getAllEvents: () => void,
+    getEventsByCategory: (categories: string[]) => void
 }
 
-function EventGallery(props:Props) {
+function EventGallery(props: Props) {
+
+    function onAllEventsClickHandler() {
+        console.log("All events clicked");
+        props.getAllEvents();
+    }
+
+    function onMyEventsClickHandler() {
+        console.log("My events clicked");
+        props.getEventsByCategory(props.user.preferredCategories);
+    }
 
     return (
-        <div className="event-gallery">
-            {props.events.map((currentEvent:EventModel)=>{
-                return <EventCard key={currentEvent.id} event={currentEvent}></EventCard>
-            })
-            }
+        <div>
+            <div>
+                <button onClick={onAllEventsClickHandler}>All events</button>
+                <button onClick={onMyEventsClickHandler}>My events</button>
+            </div>
+            <div className="event-gallery">
+
+                {props.events.map((currentEvent: EventModel) => {
+                    return <EventCard key={currentEvent.id} event={currentEvent}></EventCard>
+                })
+                }
+            </div>
         </div>
     );
 }

--- a/frontend/src/components/EventGallery.tsx
+++ b/frontend/src/components/EventGallery.tsx
@@ -14,12 +14,10 @@ type Props = {
 function EventGallery(props: Props) {
 
     function onAllEventsClickHandler() {
-        console.log("All events clicked");
         props.getAllEvents();
     }
 
     function onMyEventsClickHandler() {
-        console.log("My events clicked");
         if (props.user?.preferredCategories) {
             props.getEventsByCategory(props.user.preferredCategories);
         }

--- a/frontend/src/components/EventGallery.tsx
+++ b/frontend/src/components/EventGallery.tsx
@@ -5,7 +5,7 @@ import './EventGallery.css';
 import {User} from "../model/User";
 
 type Props = {
-    user: User,
+    user: User | undefined,
     events: EventModel[],
     getAllEvents: () => void,
     getEventsByCategory: (categories: string[]) => void
@@ -20,7 +20,9 @@ function EventGallery(props: Props) {
 
     function onMyEventsClickHandler() {
         console.log("My events clicked");
-        props.getEventsByCategory(props.user.preferredCategories);
+        if (props.user?.preferredCategories) {
+            props.getEventsByCategory(props.user.preferredCategories);
+        }
     }
 
     return (

--- a/frontend/src/components/PreferredEventCategorySelection.css
+++ b/frontend/src/components/PreferredEventCategorySelection.css
@@ -1,0 +1,3 @@
+.categoryContainer {
+    display:flex;
+}

--- a/frontend/src/components/PreferredEventCategorySelection.tsx
+++ b/frontend/src/components/PreferredEventCategorySelection.tsx
@@ -1,0 +1,52 @@
+import React, {useState} from 'react';
+import {User} from "../model/User";
+import './PreferredEventCategorySelection.css';
+
+type Props = {
+    user: User,
+    categories: string[],
+    updateUserPreferredCategories: (categories: string[]) => void
+}
+
+function PreferredEventCategorySelection(props: Props) {
+    const [selectedCategories, setSelectedCategories] = useState<string[]>(props.user.preferredCategories);
+
+    const isCategorySelected = (category: string) => {
+        return selectedCategories.includes(category);
+    };
+
+    const handleCategoryChange = (category: string) => {
+        if (isCategorySelected(category)) {
+            setSelectedCategories(selectedCategories.filter((cat) => cat !== category));
+        } else {
+            setSelectedCategories([...selectedCategories, category]);
+        }
+    };
+
+    const handleConfirmSelection = () => {
+        props.updateUserPreferredCategories(selectedCategories);
+    };
+
+    return (
+        <div>
+            <h1>Event category selection</h1>
+            <h2>Logged in user: {props.user.username}</h2>
+            <fieldset>
+                <legend>Select the event categories you are interested in:</legend>
+                {props.categories.map((category: string) => {
+                    return (
+                        <div className="categoryContainer" key={category}>
+                            <label htmlFor={category}><input type="checkbox" id={category} name={category}
+                                                             checked={isCategorySelected(category)}
+                                                             onChange={() => handleCategoryChange(category)}/> {category}
+                            </label>
+                        </div>
+                    )
+                })}
+            </fieldset>
+            <button onClick={handleConfirmSelection}>Confirm</button>
+        </div>
+    );
+}
+
+export default PreferredEventCategorySelection;

--- a/frontend/src/components/PreferredEventCategorySelection.tsx
+++ b/frontend/src/components/PreferredEventCategorySelection.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 function PreferredEventCategorySelection(props: Props) {
-    const [selectedCategories, setSelectedCategories] = useState<string[]>(props.user?.preferredCategories || []);
+    const [selectedCategories, setSelectedCategories] = useState<string[]>(props.user?.preferredCategories ?? []);
 
     const isCategorySelected = (category: string) => {
         return selectedCategories.includes(category);

--- a/frontend/src/components/PreferredEventCategorySelection.tsx
+++ b/frontend/src/components/PreferredEventCategorySelection.tsx
@@ -17,7 +17,7 @@ function PreferredEventCategorySelection(props: Props) {
 
     const handleCategoryChange = (category: string) => {
         if (isCategorySelected(category)) {
-            setSelectedCategories(selectedCategories.filter((cat) => cat !== category));
+            setSelectedCategories(selectedCategories.filter((currentCategory) => currentCategory !== category));
         } else {
             setSelectedCategories([...selectedCategories, category]);
         }

--- a/frontend/src/components/PreferredEventCategorySelection.tsx
+++ b/frontend/src/components/PreferredEventCategorySelection.tsx
@@ -3,13 +3,13 @@ import {User} from "../model/User";
 import './PreferredEventCategorySelection.css';
 
 type Props = {
-    user: User,
+    user: User | undefined,
     categories: string[],
     updateUserPreferredCategories: (categories: string[]) => void
 }
 
 function PreferredEventCategorySelection(props: Props) {
-    const [selectedCategories, setSelectedCategories] = useState<string[]>(props.user.preferredCategories);
+    const [selectedCategories, setSelectedCategories] = useState<string[]>(props.user?.preferredCategories || []);
 
     const isCategorySelected = (category: string) => {
         return selectedCategories.includes(category);
@@ -30,7 +30,7 @@ function PreferredEventCategorySelection(props: Props) {
     return (
         <div>
             <h1>Event category selection</h1>
-            <h2>Logged in user: {props.user.username}</h2>
+            <h2>Logged in user: {props.user?.username}</h2>
             <fieldset>
                 <legend>Select the event categories you are interested in:</legend>
                 {props.categories.map((category: string) => {

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -5,6 +5,7 @@ import {EventModel} from "../model/EventModel";
 export default function useEvent() {
 
     const [events, setEvents] = useState<EventModel[]>([])
+    const [categories, setCategories] = useState<string[]>([])
 
     function getAllEvents() {
         return axios.get("/api/event")
@@ -12,5 +13,65 @@ export default function useEvent() {
             .catch(error => console.log(error.message))
     }
 
-    return {getAllEvents, events}
+    function getEventsByStatus(status: string = "NEW") {
+        axios.get(`/api/event/status/${status}`)
+            .then(response => setEvents(response.data))
+            .catch(error => {
+                console.log(error.message);
+            })
+    }
+
+    function getEventsByCategory(categories: string[]) {
+        const queryParams = categories.join(',');
+        return axios
+            .get("/api/event/byCategories", { params: { categories: queryParams } })
+            .then((response) => setEvents(response.data))
+            .catch((error) => {
+                console.log(error.message);
+            });
+    }
+
+    function getEventsByCreator(creator: string) {
+        axios.get(`/api/event/creator/${creator}`)
+            .then(response => setEvents(response.data))
+            .catch(error => {
+                console.log(error.message);
+            })
+    }
+
+    function saveEvent(event: EventModel) {
+        return axios.post("/api/event", event)
+            .then(response => setEvents([...events, response.data]))
+            .catch(error => console.log(error.message))
+    }
+
+    function updateEvent(id: string, event: EventModel) {
+        return axios.put(`/api/event/${id}`, event)
+            .then(() => getEventsByStatus())
+            .catch(error => console.log(error.message))
+    }
+
+    function deleteEvent(event: EventModel, callback?: () => void) {
+        return axios
+            .delete(`/api/event/${event.id}`)
+            .then(() => {
+                if (callback) {
+                    callback();
+                } else {
+                    getAllEvents()
+                        .catch((error) => console.log(error.message));
+                }
+            })
+            .catch((error) => console.log(error.message));
+    }
+
+    function getAllCategories() {
+        return axios.get("/api/event/categories")
+            .then(response => setCategories(response.data))
+            .catch(error => console.log(error.message))
+    }
+
+    return {events, setEvents, getAllEvents, getEventsByStatus, getEventsByCategory, getEventsByCreator, saveEvent, updateEvent, deleteEvent,
+        categories, getAllCategories}
+
 }

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -2,10 +2,12 @@ import axios from "axios";
 import {useState} from "react";
 import {User} from "../model/User";
 import {toast} from 'react-toastify';
+import {useNavigate} from "react-router-dom";
 
 export default function useUser() {
 
-    const [user, setUser] = useState<User>()
+    const [user, setUser] = useState<User | undefined>(undefined);
+    const navigate = useNavigate();
 
     function register(username: string, password: string) {
         return axios.post("/api/user/register", {username, password})
@@ -38,6 +40,7 @@ export default function useUser() {
             .then(() => {
                 setUser(undefined)
                 toast.success("Logout successful");
+                navigate("/");
             })
             .catch((error) => {
                 const message =
@@ -46,6 +49,20 @@ export default function useUser() {
             });
     }
 
-    return {register, login, logout, user};
+    function updateUserPreferredCategories(selectedCategories: string[]) {
+        return axios.put("/api/user/update-preferred-categories", {username: user?.username, categories: selectedCategories})
+            .then((response) => {
+                setUser(response.data)
+                toast.success("Preferred categories updated");
+            })
+            .catch((error) => {
+                const message =
+                    error?.response?.data?.message;
+                toast.error(`Update failed: ${message}`);
+            });
+
+    }
+
+    return {user, register, login, logout, updateUserPreferredCategories};
 
 }

--- a/frontend/src/model/EventModel.ts
+++ b/frontend/src/model/EventModel.ts
@@ -3,6 +3,8 @@ export type EventModel = {
     title:string,
     description:string,
     start:Date,
+    startDate:string,
+    startTime:string,
     end:Date,
     location:string,
     category:string,

--- a/frontend/src/model/User.ts
+++ b/frontend/src/model/User.ts
@@ -2,4 +2,5 @@ export type User = {
     username:string;
     password:string;
     roles:string[];
+    preferredCategories:string[];
 }


### PR DESCRIPTION
- users now can select event categories, they are interested in (in the event gallery the button “My events” filters for events of the selected category)
- refined the views for organizers and editors

Setup for testing
setup database and import example events and users from backend/src/test/resources/
(If you already have data in your eventHubDB, please clear the collections, because there were some changes in the data format)
events.json
eventHubDB.users.json
4 users with the following username/password combinations are present then:
[admin@event.hub](mailto:admin@event.hub)/123
[organizer@event.hub](mailto:organizer@event.hub)/123
[editor@event.hub](mailto:editor@event.hub)/123
[user@event.hub](mailto:user@event.hub)/123

	•	admin is able to access all routes via the links in the nav
	•	organizer is able to access the routes /gallery and /add via the links in the nav
	•	editor is able to access the routes /gallery and /approve via the links in the nav
	•	user is able to access the route /gallery only
if you register a new user, the user will geht the role user and will be able to access the event gallery